### PR TITLE
Fix Ruff config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,8 @@
 {
     "notebook.formatOnSave.enabled": true,
     "notebook.codeActionsOnSave": {
-        "source.fixAll.ruff": true,
-        "source.organizeImports.ruff": true
+        "notebook.source.fixAll.ruff": "explicit",
+        "notebook.source.organizeImports.ruff": "explicit"
     },
     "[python]": {
         "editor.defaultFormatter": "charliermarsh.ruff",


### PR DESCRIPTION
Van [deze FAQ](https://docs.astral.sh/ruff/faq/#source-code-actions-in-notebooks) van Astral, de makers van Ruff, _"Ruff does not support source.organizeImports and source.fixAll code actions in Jupyter Notebooks (notebook.codeActionsOnSave in VS Code)."_ Deze wijziging volgt de voorgestelde verandering door `source.*` te vervangen met `notebook.source.*`. Ook is `true` vervangen door `"explicit"` omdat `true` deprecated is.